### PR TITLE
chore: better logging on error 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooks",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Three projects are included - k8s: a kubernetes hook implementation that spins up pods dynamically to run a job - docker: A hook implementation of the runner's docker implementation  - A hook lib, which contains shared typescript definitions and utilities that the other packages consume",
   "main": "",
   "directories": {

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -250,6 +250,7 @@ export async function execPodStep(
     } catch (error) {
       core.error(`Failed to exec pod step`)
       core.error(error as Error)
+      reject(error)
     }
   })
 }

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -250,7 +250,6 @@ export async function execPodStep(
     } catch (error) {
       core.error(`Failed to exec pod step`)
       core.error(error as Error)
-      reject(error)
     }
   })
 }

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -248,7 +248,8 @@ export async function execPodStep(
         }
       )
     } catch (error) {
-      core.error(`Failed to exec pod step: ${error}`)
+      core.error(`Failed to exec pod step`)
+      core.error(error as Error)
     }
   })
 }


### PR DESCRIPTION
Followup of https://github.com/promaton/runner-container-hooks/pull/9

We caught the error but it gets logged as `Object object`, hoping this change will show the full error message 🤞  